### PR TITLE
fix: fixing custom icons in buttons template

### DIFF
--- a/src/Controls/BtnTemplate.tsx
+++ b/src/Controls/BtnTemplate.tsx
@@ -36,7 +36,7 @@ const BtnTemplate = (props: BtnTemplateInterface) => {
       }}
       onClick={onClick}
     >
-      {customIcon ? (
+      {customIcon && customIcon[name] ? (
         <img src={customIcon[name]} alt={name} />
       ) : (
         <svg


### PR DESCRIPTION
There's an error when only some cusom icons are passed trough props.
Project icons aren't shown if, for example, only call end icon is in props.

This fix verify if there's a custom icon with button name and show default icon if not instead.