### PR TITLE
V2.1

### DIFF
--- a/src/AgoraUIKit.tsx
+++ b/src/AgoraUIKit.tsx
@@ -3,11 +3,7 @@
  */
 import React, { useContext, useEffect, useState } from 'react'
 import RtcConfigure from './RTCConfigure'
-import PropsContext, {
-  PropsProvider,
-  PropsInterface,
-  layout
-} from './PropsContext'
+import PropsContext, { PropsProvider, PropsInterface, layout } from './PropsContext'
 import LocalControls from './Controls/LocalControls'
 import PinnedVideo from './PinnedVideo'
 import GridVideo from './GridVideo'
@@ -24,27 +20,41 @@ import AgoraRTC, { AgoraRTCProvider, IAgoraRTCClient } from 'agora-rtc-react'
 const AgoraUIKit: React.FC<PropsInterface> = (props) => {
   const { styleProps, rtcProps } = props
   const { UIKitContainer } = styleProps || {}
-  let [client, setClient] = useState<IAgoraRTCClient | null>(null)
-
-  const setNewClient = () => {
-    let newClient = AgoraRTC.createClient({ codec: 'vp8', mode: 'live' }) // pass in another client if use h264
-    if (rtcProps.customRtcClient) {
-      // if customRtcClient prop is set then use custom client
-      newClient.removeAllListeners()
-      newClient = rtcProps.customRtcClient
-    }
-    setClient(newClient)
-  }
+  let [client, setClient] = useState<IAgoraRTCClient | undefined>(undefined)
 
   useEffect(()=> {
-    setNewClient()  // set the client when the component mounts
-  }, [])
+    if (!client) {
+      let newClient = AgoraRTC.createClient({ codec: 'vp8', mode: 'live' }) // pass in another client if use h264
+      if (rtcProps.customRtcClient) {
+        // if customRtcClient prop is set then use custom client
+        newClient.removeAllListeners()
+        newClient = rtcProps.customRtcClient
+      }
+      console.log(`-- <AgoraUIkit />: setClient `)
+      setClient(newClient)
+    }
 
+    return () => {
+      if (client) {
+        client?.leave()
+        client?.removeAllListeners()
+        setClient(undefined) 
+      }
+    }
+  }, [client])
+
+  useEffect(()=> {
+    if (client) {
+      client.leave()
+      client.removeAllListeners()
+      setClient(undefined) 
+    }
+  }, [rtcProps.role])
 
   return (
     <div id="AgoraUIKit" style={{ height: '100%' }}>
       {client && (
-        <AgoraRTCProvider client={client!}>
+        <AgoraRTCProvider client={client}>
           <PropsProvider value={props}>
             <div
               id='Agora-React-UIKit-Container'

--- a/src/AgoraUIKit.tsx
+++ b/src/AgoraUIKit.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useContext, useEffect, useState } from 'react'
 import RtcConfigure from './RTCConfigure'
-import PropsContext, { PropsProvider, PropsInterface, layout } from './PropsContext'
+import PropsContext, {  PropsProvider, PropsInterface, layout } from './PropsContext'
 import LocalControls from './Controls/LocalControls'
 import PinnedVideo from './PinnedVideo'
 import GridVideo from './GridVideo'
@@ -63,13 +63,9 @@ const AgoraUIKit: React.FC<PropsInterface> = (props) => {
                 ...UIKitContainer
               }}
             >
-              {rtcProps.role === 'audience' ? (
+              <TracksConfigure>
                 <VideocallUI />
-              ) : (
-                <TracksConfigure>
-                  <VideocallUI />
-                </TracksConfigure>
-              )}
+              </TracksConfigure>
             </div>
           </PropsProvider>
         </AgoraRTCProvider>

--- a/src/Controls/Local/muteVideo.ts
+++ b/src/Controls/Local/muteVideo.ts
@@ -13,7 +13,8 @@ export default async (
   callbacks?: Partial<CallbacksInterface>
 ) => {
   if (user.uid === 0) {
-    const localState = user.hasVideo
+    // const localState = user.hasVideo
+    const localState = localVideoTrack.enabled ? ToggleState.enabled : ToggleState.disabled
     if (
       localState === ToggleState.enabled ||
       localState === ToggleState.disabled

--- a/src/MaxVideoView.tsx
+++ b/src/MaxVideoView.tsx
@@ -3,8 +3,9 @@ import RtcContext from './RtcContext'
 import { LocalUser, RemoteUser, useRemoteUsers } from 'agora-rtc-react'
 import RemoteVideoMute from './Controls/Remote/RemoteVideoMute'
 import RemoteAudioMute from './Controls/Remote/RemoteAudioMute'
-import PropsContext, { LocalUIKitUser, UIKitUser, ToggleState } from './PropsContext'
-import { LocalContext } from './LocalUserContext'
+// import PropsContext, { LocalUIKitUser, UIKitUser, ToggleState } from './PropsContext'
+import PropsContext, { LocalUIKitUser, UIKitUser } from './PropsContext'
+// import { LocalContext } from './LocalUserContext'
 import VideoPlaceholder from './VideoPlaceholder'
 import Username from './Username'
 /**
@@ -16,7 +17,7 @@ const MaxVideoView = (props: {
 }) => {
   const { localVideoTrack, localAudioTrack } = useContext(RtcContext)
   const { styleProps, rtcProps } = useContext(PropsContext)
-  const local = useContext(LocalContext)
+  // const local = useContext(LocalContext)
   const { maxViewStyles, maxViewOverlayContainer } = styleProps || {}
   const [isShown, setIsShown] = useState(false)
   const { user } = props
@@ -25,8 +26,11 @@ const MaxVideoView = (props: {
   // Use type gaurd to check if UIKitUser is of LocalUIKitUser type
   const isLocalUser = (user: UIKitUser): user is LocalUIKitUser => user.uid === 0
 
+  console.log(`-- <MaxVideoView /> loaded for uid: ${user.uid} - isLocalUser: ${isLocalUser(user)}`)
+
   return (
     <div
+      id='Agora-React-UIKit-Max-Video-Container'
       style={{
         ...styles.container,
         ...props.style,
@@ -35,17 +39,19 @@ const MaxVideoView = (props: {
       onMouseEnter={() => setIsShown(true)}
       onMouseLeave={() => setIsShown(false)}
     >
+      {/* hasVideo is 1 if the user has video enabled, otherwise a placeholder is subbed */}
       {user.hasVideo === 1 ? (
-        // hasVideo is 1 if the local user has video enabled, or if remote user video is subbed
-        <div id="Agora-React-UIKit-Video-Grid-Local-User" style={styles.videoContainer}>
+        <div id="Agora-React-UIKit-Video-User-Container" style={styles.videoContainer}>
           {!rtcProps.disableRtm && <Username user={user} />}
+          {/* Check if user is local or remote */}
           {isLocalUser(user) ? (
             <LocalUser
+              id={`user-id-${user.uid}`}
               videoTrack={localVideoTrack} 
               audioTrack={localAudioTrack}
-              cameraOn={local.hasVideo === ToggleState.enabled ? true : false}
-              micOn={local.hasAudio === ToggleState.enabled ? true : false}
-              // playAudio
+              cameraOn={localVideoTrack?.enabled}
+              micOn={localAudioTrack?.enabled}
+              playAudio={false}
               playVideo
               style={styles.videoplayer}
             />
@@ -58,6 +64,7 @@ const MaxVideoView = (props: {
           )}
           {isShown && (
             <div
+              id='remote-video-mute-controls'
               style={{
                 ...styles.overlay,
                 ...maxViewOverlayContainer
@@ -69,7 +76,7 @@ const MaxVideoView = (props: {
           )}
         </div>
       ) : (
-        <div style={styles.videoContainer}>
+        <div id={`no-video-container`} style={styles.videoContainer}>
           {!rtcProps.disableRtm && <Username user={user} />}
           <VideoPlaceholder user={user} isShown={isShown} showButtons />
         </div>

--- a/src/RTMConfigure.tsx
+++ b/src/RTMConfigure.tsx
@@ -57,9 +57,10 @@ const RtmConfigure = (props: any) => {
     const { tokenUrl } = rtcProps
     if (tokenUrl) {
       try {
-        const res = await fetch(
-          tokenUrl + '/rtm/' + (rtmProps?.uid || localUid.current)
-        )
+        const res = await fetch(`${tokenUrl}/rtm/${rtmProps?.uid || localUid.current}/`) // tokenUrl + '/rtc/' + channel + '/publisher/uid/' + (userUid || 0) + '/' )
+        // const res = await fetch(
+        //   tokenUrl + '/rtm/' + (rtmProps?.uid || localUid.current)
+        // )
         const data = await res.json()
         const serverToken = data.rtmToken
         await rtmClient.login({
@@ -119,9 +120,10 @@ const RtmConfigure = (props: any) => {
       console.log('token expired - renewing')
       if (tokenUrl) {
         try {
-          const res = await fetch(
-            tokenUrl + '/rtm/' + (rtmProps?.uid || localUid.current)
-          )
+          const res = await fetch(`${tokenUrl}/rtm/${rtmProps?.uid || localUid.current}/`) // tokenUrl + '/rtc/' + channel + '/publisher/uid/' + (userUid || 0) + '/' )
+          // const res = await fetch(
+          //   tokenUrl + '/rtm/' + (rtmProps?.uid || localUid.current)
+          // )
           const data = await res.json()
           const serverToken = data.rtmToken
           await rtmClient.renewToken(serverToken)

--- a/src/TracksConfigure.tsx
+++ b/src/TracksConfigure.tsx
@@ -45,14 +45,17 @@ const TracksConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> =
   console.log(`-- <TracksProvider />: loaded `) // TODO: remove Testing Logs
 
   return (
-    <TracksProvider
-      value={{
-        localVideoTrack: localCameraTrack,
-        localAudioTrack: localMicrophoneTrack
-      }}
-    >
-      {ready ? props.children : null}
-    </TracksProvider>
+    props.role === 'audience' ?
+      <div>{ready ? props.children : null}</div>
+    :
+      <TracksProvider
+        value={{
+          localVideoTrack: localCameraTrack,
+          localAudioTrack: localMicrophoneTrack
+        }}
+      >
+        {ready ? props.children : null}
+      </TracksProvider>
   )
 }
 

--- a/src/TracksConfigure.tsx
+++ b/src/TracksConfigure.tsx
@@ -18,15 +18,18 @@ const TracksConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> =
   useEffect(() => {
     if(micError || cameraError) {
       console.error('Local tracks error:', { micError, cameraError })
+      console.error('-- <TracksProvider />: Local tracks error:', { micError, cameraError }) // TODO: remove Testing Logs
     }
   },[micError, cameraError])
 
   useEffect(() => {
+    console.log(`-- <TracksProvider />: ready: ${ready} `) // TODO: remove Testing Logs
     if(ready) {
       mediaStore.current[0] = {
         audioTrack: localMicrophoneTrack as ILocalAudioTrack,
         videoTrack: localCameraTrack as ILocalVideoTrack
       }
+      console.log(`-- <TracksProvider />: new tracks set `) // TODO: remove Testing Logs
     } 
     return () => {
       if (localMicrophoneTrack || localCameraTrack) {
@@ -34,9 +37,12 @@ const TracksConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> =
         localMicrophoneTrack?.close()
         // eslint-disable-next-line no-unused-expressions
         localCameraTrack?.close()
+        console.log(`-- <TracksProvider />: close tracks `) // TODO: remove Testing Logs
       }
     }
   },[ready])
+
+  console.log(`-- <TracksProvider />: loaded `) // TODO: remove Testing Logs
 
   return (
     <TracksProvider

--- a/src/VideoPlaceholder.tsx
+++ b/src/VideoPlaceholder.tsx
@@ -14,13 +14,14 @@ const VideoPlaceholder = (props: VideoPlaceholderProps) => {
 
   return !CustomVideoPlaceholder ? (
     <div
+      id='video-placeholder-container'
       key={user.uid}
       style={{
         ...style.max,
         ...maxViewStyles
       }}
     >
-      <div style={style.imgContainer}>
+      <div id={`video-placeholder-${user.uid}`} style={style.imgContainer}>
         <img
           style={style.img}
           src='data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItdXNlciI+PHBhdGggZD0iTTIwIDIxdi0yYTQgNCAwIDAgMC00LTRIOGE0IDQgMCAwIDAtNCA0djIiPjwvcGF0aD48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiPjwvY2lyY2xlPjwvc3ZnPg=='


### PR DESCRIPTION
> If you change roles to audience, then come back to host, the camera and mic do not work

This issue was related to how the `<videoCall/>` and `<TracksConfigure/>` components are mounted and unmounted by the UIKit when the role changes. in React 18 the mount and unmounts are not as clear cut as older versions of React so when the `<videoCall/>` gets mounted as part of the audience flow and then remounted as part of the host flow it causes the component to mount and unmount which creates a shadow reference in the RTCConfigure so the leave channel is properly executed. 

to resolve this issue, I moved the role logic from the main UIKit component to TracksConfigure component